### PR TITLE
Add profile card above dashboard metrics

### DIFF
--- a/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
+++ b/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
@@ -7,6 +7,14 @@ export const EcommerceMetrics = () => {
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:gap-6">
       {/* <!-- Metric Item Start --> */}
+      <div className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-white/[0.03] md:p-6 sm:col-span-2">
+        <h3 className="text-lg font-semibold text-gray-800 dark:text-white/90">
+          Sarah Watson 29 F
+        </h3>
+      </div>
+      {/* <!-- Metric Item End --> */}
+
+      {/* <!-- Metric Item Start --> */}
       <div className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-white/[0.03] md:p-6">
         <div className="flex items-center justify-center w-12 h-12 bg-gray-100 rounded-xl dark:bg-gray-800">
           <GroupIcon className="text-gray-800 size-6 dark:text-white/90" />


### PR DESCRIPTION
## Summary
- add profile card for "Sarah Watson 29 F" above metrics on dashboard

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a29ee6ab708332841e0b8848160b79