### PR TITLE
Add Patient Avatar container above Monthly Target

### DIFF
--- a/next-dashboard/src/app/(admin)/page.tsx
+++ b/next-dashboard/src/app/(admin)/page.tsx
@@ -6,6 +6,7 @@ import MonthlySalesChart from "@/components/ecommerce/MonthlySalesChart";
 import StatisticsChart from "@/components/ecommerce/StatisticsChart";
 import RecentOrders from "@/components/ecommerce/RecentOrders";
 import DemographicCard from "@/components/ecommerce/DemographicCard";
+import PatientAvatar from "@/components/ecommerce/PatientAvatar";
 
 export const metadata: Metadata = {
   title:
@@ -22,7 +23,8 @@ export default function Ecommerce() {
         <MonthlySalesChart />
       </div>
 
-      <div className="col-span-12 xl:col-span-5">
+      <div className="col-span-12 space-y-6 xl:col-span-5">
+        <PatientAvatar />
         <MonthlyTarget />
       </div>
 

--- a/next-dashboard/src/components/ecommerce/PatientAvatar.tsx
+++ b/next-dashboard/src/components/ecommerce/PatientAvatar.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Dropdown } from "../ui/dropdown/Dropdown";
+import { MoreDotIcon } from "@/icons";
+import { useState } from "react";
+import { DropdownItem } from "../ui/dropdown/DropdownItem";
+
+export default function PatientAvatar() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  function toggleDropdown() {
+    setIsOpen(!isOpen);
+  }
+
+  function closeDropdown() {
+    setIsOpen(false);
+  }
+
+  return (
+    <div className="rounded-2xl border border-gray-200 bg-gray-100 dark:border-gray-800 dark:bg-white/[0.03]">
+      <div className="px-5 pt-5 bg-white shadow-default rounded-2xl pb-11 dark:bg-gray-900 sm:px-6 sm:pt-6">
+        <div className="flex justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-gray-800 dark:text-white/90">
+              Patient Avatar
+            </h3>
+          </div>
+          <div className="relative inline-block">
+            <button onClick={toggleDropdown} className="dropdown-toggle">
+              <MoreDotIcon className="text-gray-400 hover:text-gray-700 dark:hover:text-gray-300" />
+            </button>
+            <Dropdown
+              isOpen={isOpen}
+              onClose={closeDropdown}
+              className="w-40 p-2"
+            >
+              <DropdownItem
+                tag="a"
+                onItemClick={closeDropdown}
+                className="flex w-full font-normal text-left text-gray-500 rounded-lg hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-gray-300"
+              >
+                View More
+              </DropdownItem>
+              <DropdownItem
+                tag="a"
+                onItemClick={closeDropdown}
+                className="flex w-full font-normal text-left text-gray-500 rounded-lg hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-gray-300"
+              >
+                Delete
+              </DropdownItem>
+            </Dropdown>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Patient Avatar container duplicating Monthly Target styling with empty content
- show Patient Avatar above Monthly Target on the dashboard page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a29feccc848332bbe1e6a1f7e5a26d