### PR TITLE
Add patient badges for Sarah Watson

### DIFF
--- a/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
+++ b/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
@@ -11,6 +11,20 @@ export const EcommerceMetrics = () => {
         <h3 className="text-lg font-semibold text-gray-800 dark:text-white/90">
           Sarah Watson 29 F
         </h3>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <Badge variant="solid" color="warning">
+            Clinical need: High
+          </Badge>
+          <Badge variant="solid" color="info">
+            Medication change
+          </Badge>
+          <Badge variant="solid" color="info">
+            Certificate
+          </Badge>
+          <Badge variant="solid" color="info">
+            English as second language
+          </Badge>
+        </div>
       </div>
       {/* <!-- Metric Item End --> */}
 


### PR DESCRIPTION
## Summary
- show patient context tags for Sarah Watson using solid badges
- highlight high clinical need with orange badge

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2a2d1693c8332816f09b7766120ab