### PR TITLE
Improve ICE Model layout responsiveness and styling

### DIFF
--- a/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
+++ b/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
@@ -33,47 +33,24 @@ export const EcommerceMetrics = () => {
         <h3 className="text-lg font-semibold text-gray-800 dark:text-white/90">
           ICE Model
         </h3>
-        <div className="flex flex-col gap-2 mt-4">
-          <button className="px-4 py-2 text-left text-white rounded-lg bg-purple-800">
-            Idea: I think I&apos;m tired from work and stressed at home, giving me a headache
-          </button>
-          <button className="px-4 py-2 text-left text-white rounded-lg bg-purple-800">
-            Concerns: I&apos;m worried about potential heart problems
-          </button>
-          <button className="px-4 py-2 text-left text-white rounded-lg bg-purple-800">
-            Expectation: I want reassurance and a medical certificate to take time off of work
-          </button>
-        </div>
-      </div>
-      {/* <!-- Metric Item End --> */}
-
-      {/* <!-- Metric Item Start --> */}
-      <div className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-white/[0.03] md:p-6 sm:col-span-2">
-        <h3 className="text-lg font-semibold text-gray-800 dark:text-white/90">
-          ICE Model
-        </h3>
-        <div className="grid grid-cols-2 gap-2 mt-4">
-          <div className="flex flex-col gap-2">
-            <button className="px-4 py-2 text-left rounded-lg bg-gray-100 text-gray-700 dark:bg-white/5 dark:text-white/80">
-              Idea
-            </button>
-            <button className="px-4 py-2 text-left rounded-lg bg-gray-100 text-gray-700 dark:bg-white/5 dark:text-white/80">
-              Concerns
-            </button>
-            <button className="px-4 py-2 text-left rounded-lg bg-gray-100 text-gray-700 dark:bg-white/5 dark:text-white/80">
-              Expectation
-            </button>
+        <div className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-[max-content,1fr]">
+          <div className="px-4 py-2 text-left text-white rounded-lg bg-[#465fff]">
+            Idea
           </div>
-          <div className="flex flex-col gap-2">
-            <div className="px-4 py-2 text-left text-white rounded-lg bg-[#465fff]">
-              I think I&apos;m tired from work and stressed at home, giving me a headache
-            </div>
-            <div className="px-4 py-2 text-left text-white rounded-lg bg-[#465fff]">
-              I&apos;m worried about potential heart problems
-            </div>
-            <div className="px-4 py-2 text-left text-white rounded-lg bg-[#465fff]">
-              I want reassurance and a medical certificate to take time off of work
-            </div>
+          <div className="px-4 py-2 text-left rounded-lg bg-gray-100 text-gray-700 dark:bg-white/5 dark:text-white/80">
+            I think I&apos;m tired from work and stressed at home, giving me a headache
+          </div>
+          <div className="px-4 py-2 text-left text-white rounded-lg bg-[#465fff]">
+            Concerns
+          </div>
+          <div className="px-4 py-2 text-left rounded-lg bg-gray-100 text-gray-700 dark:bg-white/5 dark:text-white/80">
+            I&apos;m worried about potential heart problems
+          </div>
+          <div className="px-4 py-2 text-left text-white rounded-lg bg-[#465fff]">
+            Expectation
+          </div>
+          <div className="px-4 py-2 text-left rounded-lg bg-gray-100 text-gray-700 dark:bg-white/5 dark:text-white/80">
+            I want reassurance and a medical certificate to take time off of work
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- refactor ICE Model into responsive two-column grid with labels sized to longest word
- invert colors so labels use blue background and descriptions use light grey
- allow layout to stack vertically on narrow screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2b23554848332885e9a3821af8231