### PR TITLE
fix: use correct logo in mobile header

### DIFF
--- a/next-dashboard/src/layout/AppHeader.tsx
+++ b/next-dashboard/src/layout/AppHeader.tsx
@@ -88,14 +88,14 @@ const AppHeader: React.FC = () => {
               width={154}
               height={32}
               className="dark:hidden"
-              src="./images/logo/logo.svg"
+              src="/images/logo/Align-Logo-with-words.svg"
               alt="Logo"
             />
             <Image
               width={154}
               height={32}
               className="hidden dark:block"
-              src="./images/logo/logo-dark.svg"
+              src="/images/logo/Align-Logo-with-words.svg"
               alt="Logo"
             />
           </Link>


### PR DESCRIPTION
## Summary
- show correct Align logo in mobile header instead of TailAdmin logo

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a464f210d88332abae86477e9f2cb6