### PR TITLE
feat: add skinny info alert and integrate into ICE card

### DIFF
--- a/next-dashboard/src/app/(admin)/(ui-elements)/alerts/page.tsx
+++ b/next-dashboard/src/app/(admin)/(ui-elements)/alerts/page.tsx
@@ -80,6 +80,24 @@ export default function Alerts() {
             showLink={false}
           />
         </ComponentCard>
+        <ComponentCard title="Skinny Info Alert">
+          <Alert
+            variant="info"
+            title="Info Message"
+            message="Be cautious when performing this action."
+            showLink={true}
+            linkHref="/"
+            linkText="Learn more"
+            size="sm"
+          />
+          <Alert
+            variant="info"
+            title="Info Message"
+            message="Be cautious when performing this action."
+            showLink={false}
+            size="sm"
+          />
+        </ComponentCard>
       </div>
     </div>
   );

--- a/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
+++ b/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import Badge from "../ui/badge/Badge";
 import { ArrowDownIcon, ArrowUpIcon, BoxIconLine, GroupIcon } from "@/icons";
+import Alert from "@/components/ui/alert/Alert";
 
 export const EcommerceMetrics: React.FC = () => {
   return (
@@ -43,6 +44,13 @@ export const EcommerceMetrics: React.FC = () => {
         <h3 className="text-lg font-semibold text-gray-800 dark:text-white/90">
           ICE Model
         </h3>
+        <div className="mt-3">
+          <Alert
+            variant="info"
+            message="This Pre-consult was translated from Korean"
+            size="sm"
+          />
+        </div>
 
         <dl className="mt-4 grid grid-cols-1 sm:grid-cols-[max-content_1fr] gap-x-3 gap-y-2 items-start md:gap-x-4 md:gap-y-3">
           {/* Idea */}

--- a/next-dashboard/src/components/ui/alert/Alert.tsx
+++ b/next-dashboard/src/components/ui/alert/Alert.tsx
@@ -3,11 +3,12 @@ import React from "react";
 
 interface AlertProps {
   variant: "success" | "error" | "warning" | "info"; // Alert type
-  title: string; // Title of the alert
+  title?: string; // Title of the alert
   message: string; // Message of the alert
   showLink?: boolean; // Whether to show the "Learn More" link
   linkHref?: string; // Link URL
   linkText?: string; // Link text
+  size?: "default" | "sm"; // Size of the alert
 }
 
 const Alert: React.FC<AlertProps> = ({
@@ -17,6 +18,7 @@ const Alert: React.FC<AlertProps> = ({
   showLink = false,
   linkHref = "#",
   linkText = "Learn more",
+  size = "default",
 }) => {
   // Tailwind classes for each variant
   const variantClasses = {
@@ -42,13 +44,15 @@ const Alert: React.FC<AlertProps> = ({
     },
   };
 
+  const iconSize = size === "sm" ? 20 : 24;
+
   // Icon for each variant
   const icons = {
     success: (
       <svg
         className="fill-current"
-        width="24"
-        height="24"
+        width={iconSize}
+        height={iconSize}
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
@@ -62,8 +66,8 @@ const Alert: React.FC<AlertProps> = ({
     error: (
       <svg
         className="fill-current"
-        width="24"
-        height="24"
+        width={iconSize}
+        height={iconSize}
         viewBox="0 0 24 24"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
@@ -79,8 +83,8 @@ const Alert: React.FC<AlertProps> = ({
     warning: (
       <svg
         className="fill-current"
-        width="24"
-        height="24"
+        width={iconSize}
+        height={iconSize}
         viewBox="0 0 24 24"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
@@ -96,8 +100,8 @@ const Alert: React.FC<AlertProps> = ({
     info: (
       <svg
         className="fill-current"
-        width="24"
-        height="24"
+        width={iconSize}
+        height={iconSize}
         viewBox="0 0 24 24"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
@@ -112,19 +116,19 @@ const Alert: React.FC<AlertProps> = ({
     ),
   };
 
+  const padding = size === "sm" ? "px-4 py-3" : "p-4";
+
   return (
-    <div
-      className={`rounded-xl border p-4 ${variantClasses[variant].container}`}
-    >
+    <div className={`rounded-xl border ${padding} ${variantClasses[variant].container}`}>
       <div className="flex items-start gap-3">
-        <div className={`-mt-0.5 ${variantClasses[variant].icon}`}>
-          {icons[variant]}
-        </div>
+        <div className={`-mt-0.5 ${variantClasses[variant].icon}`}>{icons[variant]}</div>
 
         <div>
-          <h4 className="mb-1 text-sm font-semibold text-gray-800 dark:text-white/90">
-            {title}
-          </h4>
+          {title && (
+            <h4 className="mb-1 text-sm font-semibold text-gray-800 dark:text-white/90">
+              {title}
+            </h4>
+          )}
 
           <p className="text-sm text-gray-500 dark:text-gray-400">{message}</p>
 


### PR DESCRIPTION
## Summary
- add optional size to Alert for compact display
- document skinny info alert in UI elements
- show translation notice on ICE model card

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5620150d483328294b86b20b03571