### PR TITLE
Revamp presentations card layout and patient card sizing

### DIFF
--- a/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
+++ b/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
@@ -34,8 +34,8 @@ export const EcommerceMetrics: React.FC = () => {
         </div>
 
         {/* Attached grey footer (duplicated style) */}
-        <div className="flex items-center justify-center gap-5 px-6 py-3.5 sm:gap-8 sm:py-5">
-          <dt className="rounded-lg bg-gray-100 text-gray-700 dark:bg-white/5 dark:text-white/80">
+        <div className="flex items-center justify-center gap-5 px-6 py-3 sm:gap-8 sm:py-4">
+          <dt className="rounded-lg bg-gray-100 text-gray-700 dark:bg-white/5 dark:text-white/80 text-sm line-clamp-3">
             Patient’s headache began 2 weeks ago, worsening over the duration. Consistent pain with intermittent sharpness. Exacerbates with stress. No nausea or vomiting. Currently takes panadol.
           </dt>
         </div>

--- a/next-dashboard/src/components/ecommerce/PresentationTabs.tsx
+++ b/next-dashboard/src/components/ecommerce/PresentationTabs.tsx
@@ -15,56 +15,40 @@ const PresentationTabs: React.FC = () => {
     }
   };
 
+  const copyText = selected === "chest" ? chestPainText : headacheText;
+
   const renderChestPain = () => (
     <div>
-      <div className="flex justify-end mb-4">
-        <button
-          onClick={() => copyToClipboard(chestPainText)}
-          className="p-2 text-gray-500 rounded-md hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          aria-label="Copy chest pain details"
-        >
-          <CopyIcon className="size-4" />
-        </button>
-      </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <div className="grid grid-cols-5 gap-4">
         <div className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-white/[0.03]">
-          <span className="text-sm text-gray-500 dark:text-gray-400">Severity</span>
+          <span className="text-base text-gray-800 dark:text-white/90">Severity</span>
           <h4 className="mt-2 font-bold text-gray-800 text-title-sm dark:text-white/90">6/10</h4>
         </div>
         <div className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-white/[0.03]">
-          <span className="text-sm text-gray-500 dark:text-gray-400">Onset</span>
+          <span className="text-base text-gray-800 dark:text-white/90">Onset</span>
           <h4 className="mt-2 font-bold text-gray-800 text-title-sm dark:text-white/90">Uncertain</h4>
           <p className="mt-2 text-gray-500 text-theme-xs dark:text-gray-400">
             Experienced for more than a few months, uncertain for how long.
           </p>
         </div>
         <div className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-white/[0.03]">
-          <span className="text-sm text-gray-500 dark:text-gray-400">Character</span>
+          <span className="text-base text-gray-800 dark:text-white/90">Character</span>
           <h4 className="mt-2 font-bold text-gray-800 text-title-sm dark:text-white/90">Stinging pain</h4>
         </div>
         <div className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-white/[0.03]">
-          <span className="text-sm text-gray-500 dark:text-gray-400">Related Symptoms</span>
+          <span className="text-base text-gray-800 dark:text-white/90">Related Symptoms</span>
           <h4 className="mt-2 font-bold text-gray-800 text-title-sm dark:text-white/90">0 Indicated</h4>
         </div>
-      </div>
-      <div className="mt-4 rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-white/[0.03]">
-        <span className="text-sm text-gray-500 dark:text-gray-400">Current Management</span>
-        <h4 className="mt-2 font-bold text-gray-800 text-title-sm dark:text-white/90">No steps taken</h4>
+        <div className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-white/[0.03]">
+          <span className="text-base text-gray-800 dark:text-white/90">Current Management</span>
+          <p className="mt-2 text-gray-500 text-theme-xs dark:text-gray-400">No steps taken</p>
+        </div>
       </div>
     </div>
   );
 
   const renderHeadache = () => (
     <div>
-      <div className="flex justify-end mb-4">
-        <button
-          onClick={() => copyToClipboard(headacheText)}
-          className="p-2 text-gray-500 rounded-md hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          aria-label="Copy headache details"
-        >
-          <CopyIcon className="size-4" />
-        </button>
-      </div>
       <p className="text-gray-500 dark:text-gray-400">No details available.</p>
     </div>
   );
@@ -72,28 +56,37 @@ const PresentationTabs: React.FC = () => {
   return (
     <div className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-white/[0.03] md:p-6 sm:col-span-2">
       <div className="mb-4">
-        <span className="text-sm text-gray-500 dark:text-gray-400">2 Presentations</span>
+        <h3 className="text-lg font-semibold text-gray-800 dark:text-white/90">2 Presentations</h3>
       </div>
-      <div className="mb-6 flex gap-2">
+      <div className="mb-6 flex items-center justify-between gap-2">
+        <div className="flex gap-2">
+          <button
+            onClick={() => setSelected("chest")}
+            className={`px-4 py-2 rounded-lg text-sm font-medium focus:outline-none ${
+              selected === "chest"
+                ? "bg-[#465fff] text-white"
+                : "bg-gray-100 text-gray-500 dark:bg-white/5 dark:text-gray-400"
+            }`}
+          >
+            Chest Pain
+          </button>
+          <button
+            onClick={() => setSelected("headache")}
+            className={`px-4 py-2 rounded-lg text-sm font-medium focus:outline-none ${
+              selected === "headache"
+                ? "bg-[#465fff] text-white"
+                : "bg-gray-100 text-gray-500 dark:bg-white/5 dark:text-gray-400"
+            }`}
+          >
+            Headache
+          </button>
+        </div>
         <button
-          onClick={() => setSelected("chest")}
-          className={`px-4 py-2 rounded-lg text-sm font-medium focus:outline-none ${
-            selected === "chest"
-              ? "bg-[#465fff] text-white"
-              : "bg-gray-100 text-gray-500 dark:bg-white/5 dark:text-gray-400"
-          }`}
+          onClick={() => copyToClipboard(copyText)}
+          className="p-2 text-gray-500 rounded-md hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+          aria-label="Copy presentation details"
         >
-          Chest Pain
-        </button>
-        <button
-          onClick={() => setSelected("headache")}
-          className={`px-4 py-2 rounded-lg text-sm font-medium focus:outline-none ${
-            selected === "headache"
-              ? "bg-[#465fff] text-white"
-              : "bg-gray-100 text-gray-500 dark:bg-white/5 dark:text-gray-400"
-          }`}
-        >
-          Headache
+          <CopyIcon className="size-4" />
         </button>
       </div>
       {selected === "chest" ? renderChestPain() : renderHeadache()}


### PR DESCRIPTION
## Summary
- Style "2 Presentations" header to match other cards and move copy button beside tabs
- Flatten presentation details into a single-row grid and harmonize label fonts
- Reduce patient card footer height for more space on screen

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a578aa647083329674e1dd2f536a7a