### PR TITLE
Clarify pre-consultation timestamp label

### DIFF
--- a/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
+++ b/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
@@ -19,7 +19,7 @@ export const EcommerceMetrics: React.FC = () => {
                 Sarah Watson 29 F
               </h3>
               <p className="mt-1 text-gray-500 text-theme-xs dark:text-gray-400">
-                Pre-consultation submitted today at 8:15 AM
+                Submitted today at 8:15 AM
               </p>
             </div>
             <div className="flex flex-wrap gap-2 justify-end text-right">


### PR DESCRIPTION
## Summary
- Update pre-consultation timestamp text to "Submitted today at 8:15 AM"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx next lint .` *(no output; command terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a578f35a108332a35902a424135340