### PR TITLE
feat: add dashboard copy button

### DIFF
--- a/next-dashboard/src/app/(admin)/page.tsx
+++ b/next-dashboard/src/app/(admin)/page.tsx
@@ -6,6 +6,7 @@ import StatisticsChart from "@/components/ecommerce/StatisticsChart";
 import RecentOrders from "@/components/ecommerce/RecentOrders";
 import DemographicCard from "@/components/ecommerce/DemographicCard";
 import PatientAvatar from "@/components/ecommerce/PatientAvatar";
+import CopyDashboardButton from "@/components/ecommerce/CopyDashboardButton";
 
 export const metadata: Metadata = {
   title: "Align | Dashboard",
@@ -14,27 +15,33 @@ export const metadata: Metadata = {
 
 export default function Ecommerce() {
   return (
-    <div className="grid grid-cols-12 gap-4 md:gap-6">
-      <div className="col-span-12 space-y-6 xl:col-span-7">
-        <EcommerceMetrics />
-
-        <MonthlySalesChart />
+    <div>
+      <div className="flex justify-end mb-4">
+        <CopyDashboardButton />
       </div>
 
-      <div className="col-span-12 space-y-6 xl:col-span-5">
-        <PatientAvatar />
-      </div>
+      <div id="dashboard-content" className="grid grid-cols-12 gap-4 md:gap-6">
+        <div className="col-span-12 space-y-6 xl:col-span-7">
+          <EcommerceMetrics />
 
-      <div className="col-span-12">
-        <StatisticsChart />
-      </div>
+          <MonthlySalesChart />
+        </div>
 
-      <div className="col-span-12 xl:col-span-5">
-        <DemographicCard />
-      </div>
+        <div className="col-span-12 space-y-6 xl:col-span-5">
+          <PatientAvatar />
+        </div>
 
-      <div className="col-span-12 xl:col-span-7">
-        <RecentOrders />
+        <div className="col-span-12">
+          <StatisticsChart />
+        </div>
+
+        <div className="col-span-12 xl:col-span-5">
+          <DemographicCard />
+        </div>
+
+        <div className="col-span-12 xl:col-span-7">
+          <RecentOrders />
+        </div>
       </div>
     </div>
   );

--- a/next-dashboard/src/components/ecommerce/CopyDashboardButton.tsx
+++ b/next-dashboard/src/components/ecommerce/CopyDashboardButton.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { CopyIcon } from "@/icons";
+import Button from "@/components/ui/button/Button";
+
+export default function CopyDashboardButton() {
+  const handleCopy = () => {
+    const dashboard = document.getElementById("dashboard-content");
+    if (dashboard) {
+      const clone = dashboard.cloneNode(true) as HTMLElement;
+      const avatar = clone.querySelector("[data-patient-avatar]");
+      if (avatar) {
+        avatar.remove();
+      }
+      const text = clone.innerText;
+      navigator.clipboard.writeText(text);
+    }
+  };
+
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      onClick={handleCopy}
+      startIcon={<CopyIcon className="w-4 h-4" />}
+    >
+      <span className="sr-only">Copy dashboard text</span>
+    </Button>
+  );
+}

--- a/next-dashboard/src/components/ecommerce/PatientAvatar.tsx
+++ b/next-dashboard/src/components/ecommerce/PatientAvatar.tsx
@@ -20,7 +20,10 @@ export default function PatientAvatar() {
   }
 
   return (
-    <div className="rounded-2xl border border-gray-200 bg-gray-100 dark:border-gray-800 dark:bg-white/[0.03]">
+    <div
+      data-patient-avatar
+      className="rounded-2xl border border-gray-200 bg-gray-100 dark:border-gray-800 dark:bg-white/[0.03]"
+    >
       <div className="px-5 pt-5 bg-white shadow-default rounded-2xl pb-11 dark:bg-gray-900 sm:px-6 sm:pt-6">
         <div className="flex justify-between">
           <div>


### PR DESCRIPTION
## Summary
- add copy button for dashboard cards
- mark patient avatar for exclusion from copy
- implement client-side copy utility

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a58549e5ec8332a57a0688f5d44328