### PR TITLE
Expand presentations card and improve toggle buttons

### DIFF
--- a/next-dashboard/src/app/(admin)/page.tsx
+++ b/next-dashboard/src/app/(admin)/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { EcommerceMetrics } from "@/components/ecommerce/EcommerceMetrics";
 import React from "react";
 import PatientAvatar from "@/components/ecommerce/PatientAvatar";
+import PresentationTabs from "@/components/ecommerce/PresentationTabs";
 
 export const metadata: Metadata = {
   title: "Align | Dashboard",
@@ -17,6 +18,10 @@ export default function Ecommerce() {
 
       <div className="col-span-12 space-y-6 xl:col-span-5">
         <PatientAvatar />
+      </div>
+
+      <div className="col-span-12">
+        <PresentationTabs />
       </div>
     </div>
   );

--- a/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
+++ b/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
@@ -4,7 +4,6 @@ import React, { useState } from "react";
 import Badge from "../ui/badge/Badge";
 import { MoreDotIcon } from "@/icons";
 import Alert from "@/components/ui/alert/Alert";
-import PresentationTabs from "./PresentationTabs";
 import { Dropdown } from "../ui/dropdown/Dropdown";
 import { DropdownItem } from "../ui/dropdown/DropdownItem";
 
@@ -117,10 +116,6 @@ export const EcommerceMetrics: React.FC = () => {
           </dd>
         </dl>
       </div>
-
-      {/* Presentations Card */}
-      <PresentationTabs />
-
     </div>
   );
 };

--- a/next-dashboard/src/components/ecommerce/PresentationTabs.tsx
+++ b/next-dashboard/src/components/ecommerce/PresentationTabs.tsx
@@ -15,7 +15,10 @@ const PresentationTabs: React.FC = () => {
     }
   };
 
-  const copyText = selected === "chest" ? chestPainText : headacheText;
+  const copyText =
+    selected === "chest"
+      ? `Chest Pain\n${chestPainText}`
+      : `Headache\n${headacheText}`;
 
   const getButtonClass = (option: "chest" | "headache") =>
     selected === option
@@ -59,7 +62,7 @@ const PresentationTabs: React.FC = () => {
   );
 
   return (
-    <div className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-white/[0.03] md:p-6 sm:col-span-2">
+    <div className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-white/[0.03] md:p-6">
       <div className="flex flex-col gap-5 mb-6 sm:flex-row sm:justify-between">
         <div className="w-full">
           <h3 className="text-lg font-semibold text-gray-800 dark:text-white/90">2 Presentations</h3>
@@ -68,7 +71,7 @@ const PresentationTabs: React.FC = () => {
           <div className="flex items-center gap-0.5 rounded-lg bg-gray-100 p-0.5 dark:bg-gray-900">
             <button
               onClick={() => setSelected("chest")}
-              className={`px-3 py-2 font-medium w-full rounded-md text-theme-sm hover:text-gray-900 dark:hover:text-white ${getButtonClass(
+              className={`px-3 py-2 font-medium rounded-md text-theme-sm whitespace-nowrap hover:text-gray-900 dark:hover:text-white ${getButtonClass(
                 "chest"
               )}`}
             >
@@ -76,7 +79,7 @@ const PresentationTabs: React.FC = () => {
             </button>
             <button
               onClick={() => setSelected("headache")}
-              className={`px-3 py-2 font-medium w-full rounded-md text-theme-sm hover:text-gray-900 dark:hover:text-white ${getButtonClass(
+              className={`px-3 py-2 font-medium rounded-md text-theme-sm whitespace-nowrap hover:text-gray-900 dark:hover:text-white ${getButtonClass(
                 "headache"
               )}`}
             >


### PR DESCRIPTION
## Summary
- Move presentations card to page layout to span full dashboard width
- Make presentation toggle buttons auto-size with no wrapping
- Copy button now includes selected presentation label in clipboard text

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a58a39b5848332b36f9e25a7824b55