### PR TITLE
fix: update dark mode logos

### DIFF
--- a/next-dashboard/src/layout/AppHeader.tsx
+++ b/next-dashboard/src/layout/AppHeader.tsx
@@ -95,7 +95,7 @@ const AppHeader: React.FC = () => {
               width={154}
               height={32}
               className="hidden dark:block"
-              src="/images/logo/Align-Logo-with-words.svg"
+              src="/images/logo/Align-logo-with-words-dark-mode.svg"
               alt="Logo"
             />
           </Link>

--- a/next-dashboard/src/layout/AppSidebar.tsx
+++ b/next-dashboard/src/layout/AppSidebar.tsx
@@ -319,7 +319,7 @@ const AppSidebar: React.FC = () => {
               />
               <Image
                 className="hidden dark:block"
-                src="/images/logo/Align-Logo-with-words.svg"
+                src="/images/logo/Align-logo-with-words-dark-mode.svg"
                 alt="Logo"
                 width={150}
                 height={40}


### PR DESCRIPTION
## Summary
- swap dark mode sidebar logo to `Align-logo-with-words-dark-mode.svg`
- swap dark mode mobile header logo to `Align-logo-with-words-dark-mode.svg`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a59da75b7083329c46a50c4abe179c