### PR TITLE
feat: add waiting room page

### DIFF
--- a/next-dashboard/src/app/(admin)/(others-pages)/waiting-room/page.tsx
+++ b/next-dashboard/src/app/(admin)/(others-pages)/waiting-room/page.tsx
@@ -1,0 +1,107 @@
+import PageBreadcrumb from "@/components/common/PageBreadCrumb";
+import PatientCard from "@/components/waiting-room/PatientCard";
+import type { Metadata } from "next";
+import React from "react";
+
+export const metadata: Metadata = {
+  title: "Waiting Room",
+  description: "Upcoming patients in the waiting room",
+};
+
+const schedule = [
+  {
+    time: "9:00 AM",
+    name: "James Park",
+    age: 35,
+    submittedAt: "8:50 AM",
+    tags: ["English as Second Language"],
+    duration: 15,
+  },
+  {
+    time: "9:15 AM",
+    name: "Maria Rodriguez",
+    age: 42,
+    submittedAt: "9:02 AM",
+    tags: ["Certificate"],
+    duration: 15,
+  },
+  {
+    time: "9:30 AM",
+    name: "Wei Chen",
+    age: 30,
+    submittedAt: "9:10 AM",
+    tags: ["New Patient", "English as Second Language"],
+    duration: 30,
+  },
+  {
+    time: "10:00 AM",
+    name: "Hannah Smith",
+    age: 27,
+    submittedAt: "9:30 AM",
+    tags: ["Certificate"],
+    duration: 15,
+  },
+  {
+    time: "10:15 AM",
+    name: "Omar Khan",
+    age: 54,
+    submittedAt: "9:45 AM",
+    tags: ["English as Second Language"],
+    duration: 15,
+  },
+];
+
+export default function WaitingRoom() {
+  return (
+    <div>
+      <PageBreadcrumb pageTitle="Waiting Room" />
+
+      <section className="mb-8">
+        <h2 className="mb-4 text-lg font-semibold text-gray-800 dark:text-white/90">
+          Next Patient
+        </h2>
+        <PatientCard
+          name="Eunji Lee"
+          age={32}
+          submittedAt="8:15 AM"
+          tags={["English as Second Language", "Certificate"]}
+          bulletPoints={["Chest Pain", "Headache"]}
+          link="/"
+        />
+      </section>
+
+      <section>
+        <h2 className="mb-2 text-lg font-semibold text-gray-800 dark:text-white/90">
+          Your Schedule
+        </h2>
+        <div className="mb-4 text-sm text-blue-600 underline cursor-pointer">
+          view earlier consults
+        </div>
+        <div className="relative max-h-[500px] overflow-y-auto pl-24">
+          <div className="absolute left-20 top-0 bottom-0 w-px bg-gray-200"></div>
+          {schedule.map((item) => (
+            <div
+              key={item.time}
+              className={`flex ${item.duration === 30 ? "mb-16" : "mb-8"}`}
+            >
+              <div className="w-16 pr-4 text-right text-sm text-gray-500 dark:text-gray-400">
+                {item.time}
+              </div>
+              <div className="relative flex-1">
+                <span className="absolute -left-[22px] top-2 h-4 w-4 rounded-full bg-blue-500"></span>
+                <PatientCard
+                  name={item.name}
+                  age={item.age}
+                  submittedAt={item.submittedAt}
+                  tags={item.tags}
+                  className={item.duration === 30 ? "h-40" : ""}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/next-dashboard/src/components/waiting-room/PatientCard.tsx
+++ b/next-dashboard/src/components/waiting-room/PatientCard.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import Link from "next/link";
+
+interface PatientCardProps {
+  name: string;
+  age: number;
+  submittedAt?: string;
+  tags: string[];
+  bulletPoints?: string[];
+  link?: string;
+  className?: string;
+}
+
+const PatientCard: React.FC<PatientCardProps> = ({
+  name,
+  age,
+  submittedAt,
+  tags,
+  bulletPoints,
+  link,
+  className = "",
+}) => {
+  return (
+    <div
+      className={`relative rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-white/[0.03] ${className}`}
+    >
+      <div>
+        <h3 className="text-base font-semibold text-gray-800 dark:text-white/90">
+          {name}
+        </h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          {age} yrs{submittedAt ? ` \u2022 submitted ${submittedAt}` : ""}
+        </p>
+      </div>
+      {bulletPoints && (
+        <ul className="mt-3 list-disc pl-5 text-base font-semibold text-gray-700 dark:text-gray-300">
+          {bulletPoints.map((point) => (
+            <li key={point}>{point}</li>
+          ))}
+        </ul>
+      )}
+      <div className="mt-3 flex flex-wrap gap-2">
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            className="rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600 dark:bg-white/10 dark:text-white/80"
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+      {link && (
+        <div className="mt-4 text-right">
+          <Link href={link} className="text-sm font-medium text-blue-600 underline">
+            view pre-consult
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PatientCard;
+

--- a/next-dashboard/src/layout/AppSidebar.tsx
+++ b/next-dashboard/src/layout/AppSidebar.tsx
@@ -37,6 +37,11 @@ const navItems: NavItem[] = [
     path: "/calendar",
   },
   {
+    icon: <HorizontaLDots />,
+    name: "Waiting Room",
+    path: "/waiting-room",
+  },
+  {
     icon: <UserCircleIcon />,
     name: "User Profile",
     path: "/profile",


### PR DESCRIPTION
## Summary
- add Waiting Room navigation link
- implement reusable patient card component
- create Waiting Room page with next patient card and schedule timeline

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b50b133a2c83328c22aa037cb77c94