### PR TITLE
Add waiting room page and timeline schedule

### DIFF
--- a/next-dashboard/src/app/(admin)/waiting-room/page.tsx
+++ b/next-dashboard/src/app/(admin)/waiting-room/page.tsx
@@ -1,0 +1,137 @@
+import type { Metadata } from "next";
+import PatientCard from "@/components/waiting-room/PatientCard";
+import React from "react";
+
+export const metadata: Metadata = {
+  title: "Align | Waiting Room",
+  description: "Upcoming patients in the waiting room",
+};
+
+interface ScheduleItem {
+  time: string;
+  patient: {
+    name: string;
+    age: number;
+    gender: string;
+    submittedAt: string;
+    tags: string[];
+    conditions: string[];
+  };
+  duration?: number;
+}
+
+const schedule: ScheduleItem[] = [
+  {
+    time: "9:00 AM",
+    patient: {
+      name: "Minseo Park",
+      age: 28,
+      gender: "F",
+      submittedAt: "8:45 AM",
+      tags: ["English as second language"],
+      conditions: ["Sore Throat", "Fatigue"],
+    },
+  },
+  {
+    time: "9:15 AM",
+    patient: {
+      name: "Lucas Kim",
+      age: 45,
+      gender: "M",
+      submittedAt: "8:50 AM",
+      tags: ["Certificate"],
+      conditions: ["Back Pain"],
+    },
+  },
+  {
+    time: "9:30 AM",
+    patient: {
+      name: "Hannah Lee",
+      age: 30,
+      gender: "F",
+      submittedAt: "9:10 AM",
+      tags: ["New Patient"],
+      conditions: ["Annual Checkup"],
+    },
+    duration: 30,
+  },
+  {
+    time: "10:00 AM",
+    patient: {
+      name: "Noah Choi",
+      age: 35,
+      gender: "M",
+      submittedAt: "9:20 AM",
+      tags: ["English as second language"],
+      conditions: ["Allergy"],
+    },
+  },
+  {
+    time: "10:15 AM",
+    patient: {
+      name: "Soojin Park",
+      age: 25,
+      gender: "F",
+      submittedAt: "9:50 AM",
+      tags: ["Certificate"],
+      conditions: ["Flu"],
+    },
+  },
+];
+
+export default function WaitingRoom() {
+  return (
+    <div className="space-y-10">
+      <section>
+        <h2 className="text-xl font-semibold text-gray-800 dark:text-white/90 mb-4">
+          Next Patient
+        </h2>
+        <PatientCard
+          name="Eunji Lee"
+          age={33}
+          gender="F"
+          submittedAt="8:15 AM"
+          tags={[
+            "Clinical need: High",
+            "Medication change",
+            "Certificate",
+            "English as second language",
+          ]}
+          conditions={["Chest Pain", "Headache"]}
+          link="/"
+        />
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold text-gray-800 dark:text-white/90 mb-4">
+          Your Schedule
+        </h2>
+        <button className="mb-4 text-sm underline text-gray-500">
+          view earlier consults
+        </button>
+        <div className="relative">
+          <div className="absolute left-24 top-0 bottom-0 border-l border-gray-200 dark:border-gray-700"></div>
+          <ol className="space-y-8">
+            {schedule.map((item) => (
+              <li
+                key={item.time}
+                className="relative flex items-start"
+                style={{
+                  minHeight: item.duration === 30 ? "16rem" : "8rem",
+                }}
+              >
+                <time className="w-24 text-sm text-gray-500">
+                  {item.time}
+                </time>
+                <div className="ml-8 flex-1">
+                  <PatientCard {...item.patient} />
+                </div>
+                <span className="absolute left-[5.75rem] top-4 w-3 h-3 bg-brand-500 rounded-full"></span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/next-dashboard/src/components/waiting-room/PatientCard.tsx
+++ b/next-dashboard/src/components/waiting-room/PatientCard.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import Badge from "@/components/ui/badge/Badge";
+import Link from "next/link";
+
+export interface PatientCardProps {
+  name: string;
+  age: number;
+  gender: string;
+  submittedAt: string;
+  tags: string[];
+  conditions: string[];
+  link?: string;
+}
+
+const PatientCard: React.FC<PatientCardProps> = ({
+  name,
+  age,
+  gender,
+  submittedAt,
+  tags,
+  conditions,
+  link,
+}) => {
+  return (
+    <div className="rounded-2xl border border-gray-200 bg-gray-100 dark:border-gray-800 dark:bg-white/[0.03]">
+      <div className="px-5 pt-5 pb-5 bg-white shadow-default rounded-2xl dark:bg-gray-900">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h3 className="text-lg font-semibold text-gray-800 dark:text-white/90">
+              {name} {age} {gender}
+            </h3>
+            <p className="mt-1 text-gray-500 text-theme-xs dark:text-gray-400">
+              Submitted today at {submittedAt}
+            </p>
+          </div>
+          <div className="flex flex-col items-end gap-2">
+            <div className="flex flex-wrap gap-2 justify-end text-right">
+              {tags.map((tag) => (
+                <Badge key={tag} variant="solid" color="info">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="mt-3">
+        <div className="flex items-start justify-between gap-5 px-6 py-3 sm:gap-8 sm:py-4">
+          <div className="rounded-lg bg-gray-100 text-gray-700 dark:bg-white/5 dark:text-white/80 px-4 py-2">
+            <ul className="list-disc pl-5 space-y-1">
+              {conditions.map((c) => (
+                <li key={c} className="text-lg">
+                  {c}
+                </li>
+              ))}
+            </ul>
+          </div>
+          {link && (
+            <Link
+              href={link}
+              className="text-sm text-brand-500 underline self-end"
+            >
+              view pre-consult
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PatientCard;

--- a/next-dashboard/src/layout/AppSidebar.tsx
+++ b/next-dashboard/src/layout/AppSidebar.tsx
@@ -24,7 +24,10 @@ const navItems: NavItem[] = [
   {
     icon: <GridIcon />,
     name: "Dashboard",
-    subItems: [{ name: "Patient Profile", path: "/", pro: false }],
+    subItems: [
+      { name: "Patient Profile", path: "/", pro: false },
+      { name: "Waiting Room", path: "/waiting-room", pro: false },
+    ],
   },
   {
     icon: <CalenderIcon />,


### PR DESCRIPTION
## Summary
- add waiting room link in sidebar
- show next patient card and schedule timeline for upcoming consults
- create reusable patient card component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b518025ddc8332abbe19748a4d14c7