### PR TITLE
Add consultation notes with floating start button and timer

### DIFF
--- a/next-dashboard/src/components/consultation/ConsultationNotes.tsx
+++ b/next-dashboard/src/components/consultation/ConsultationNotes.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { DocsIcon, CopyIcon, CloseIcon } from '@/icons';
+
+interface ConsultationNotesProps {
+  initialContent: string;
+}
+
+const ConsultationNotes: React.FC<ConsultationNotesProps> = ({ initialContent }) => {
+  const [open, setOpen] = useState(false);
+  const [content, setContent] = useState(initialContent);
+  const [elapsed, setElapsed] = useState(0);
+  const [running, setRunning] = useState(false);
+  const [saved, setSaved] = useState(true);
+
+  useEffect(() => {
+    let interval: NodeJS.Timeout | undefined;
+    if (running) {
+      interval = setInterval(() => {
+        setElapsed((prev) => prev + 1);
+      }, 1000);
+    }
+    return () => interval && clearInterval(interval);
+  }, [running]);
+
+  useEffect(() => {
+    if (open) {
+      setRunning(true);
+    } else {
+      setRunning(false);
+      setElapsed(0);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    setSaved(false);
+    const handle = setTimeout(() => setSaved(true), 500);
+    return () => clearTimeout(handle);
+  }, [content, open]);
+
+  const formatTime = (secs: number) => {
+    const minutes = Math.floor(secs / 60);
+    const seconds = secs % 60;
+    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+  };
+
+  const copyToClipboard = () => {
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(content);
+    }
+  };
+
+  return (
+    <>
+      {!open && (
+        <button
+          onClick={() => setOpen(true)}
+          className="fixed bottom-6 right-6 z-50 flex items-center gap-2 rounded-full bg-brand-500 px-4 py-3 text-white shadow-lg"
+        >
+          <DocsIcon className="h-5 w-5" />
+          <span>Start Consultation</span>
+        </button>
+      )}
+
+      {open && (
+        <div className="fixed bottom-6 right-6 z-50 flex h-80 w-96 flex-col rounded-2xl bg-white shadow-lg dark:bg-gray-900">
+          <div className="flex items-center justify-between rounded-t-2xl border-b border-gray-200 p-3 dark:border-gray-800">
+            <div className="flex items-center gap-2">
+              <span className="font-semibold">Eunji&apos;s Consultation Notes</span>
+              <span className="text-sm text-gray-500">{formatTime(elapsed)}</span>
+              <button
+                onClick={() => setRunning((prev) => !prev)}
+                className="text-sm text-brand-500"
+              >
+                {running ? 'Pause' : 'Resume'}
+              </button>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={copyToClipboard}
+                className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+              >
+                <CopyIcon className="h-5 w-5" />
+              </button>
+              <button
+                onClick={() => setOpen(false)}
+                className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+              >
+                <CloseIcon className="h-5 w-5" />
+              </button>
+            </div>
+          </div>
+          <textarea
+            className="flex-1 resize-none bg-transparent p-3 text-sm outline-none"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+          />
+          <div className="p-2 text-right text-xs text-gray-500">
+            {saved ? 'Saved' : 'Saving...'}
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ConsultationNotes;

--- a/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
+++ b/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
@@ -6,6 +6,7 @@ import { MoreDotIcon } from "@/icons";
 import Alert from "@/components/ui/alert/Alert";
 import { Dropdown } from "../ui/dropdown/Dropdown";
 import { DropdownItem } from "../ui/dropdown/DropdownItem";
+import ConsultationNotes from "@/components/consultation/ConsultationNotes";
 
 export const EcommerceMetrics: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -17,6 +18,15 @@ export const EcommerceMetrics: React.FC = () => {
   function closeMenu() {
     setIsMenuOpen(false);
   }
+
+  const initialNotes = `Eunji Lee 33 F
+Tags: Clinical need: High, Medication change, Certificate, English as second language
+
+Idea: I think I'm tired from work and stressed at home, giving me a headache
+Concerns: I'm worried about potential heart problems
+Expectation: I want reassurance and a medical certificate to take time off of work
+
+Patient’s headache began 2 weeks ago, worsening over the duration. Consistent pain with intermittent sharpness. Exacerbates with stress. No nausea or vomiting. Currently takes panadol.`;
 
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:gap-6">
@@ -120,6 +130,7 @@ export const EcommerceMetrics: React.FC = () => {
           </dd>
         </dl>
       </div>
+      <ConsultationNotes initialContent={initialNotes} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Add floating "Start Consultation" button that expands into an editable notes window with timer, pause/resume, copy and close controls
- Pre-load consultation notes with patient info, ICE model card content and presenting symptoms
- Include auto-save indicator

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b51dd60e9483329d1ab3b6f892eb69