### PR TITLE
Revamp consultation modal and notes structure

### DIFF
--- a/next-dashboard/src/components/consultation/ConsultationNotes.tsx
+++ b/next-dashboard/src/components/consultation/ConsultationNotes.tsx
@@ -65,40 +65,42 @@ const ConsultationNotes: React.FC<ConsultationNotesProps> = ({ initialContent })
       )}
 
       {open && (
-        <div className="fixed bottom-6 right-6 z-50 flex h-80 w-96 flex-col rounded-2xl bg-white shadow-lg dark:bg-gray-900">
-          <div className="flex items-center justify-between rounded-t-2xl border-b border-gray-200 p-3 dark:border-gray-800">
-            <div className="flex items-center gap-2">
-              <span className="font-semibold">Eunji&apos;s Consultation Notes</span>
-              <span className="text-sm text-gray-500">{formatTime(elapsed)}</span>
-              <button
-                onClick={() => setRunning((prev) => !prev)}
-                className="text-sm text-brand-500"
-              >
-                {running ? 'Pause' : 'Resume'}
-              </button>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="flex h-full w-full max-w-md flex-col rounded-2xl bg-white shadow-lg dark:bg-gray-900 sm:h-80 sm:w-96">
+            <div className="flex items-center justify-between rounded-t-2xl bg-gray-100 p-3 dark:bg-gray-800">
+              <div className="flex items-center gap-2">
+                <span className="font-semibold text-gray-800 dark:text-white">Eunji&apos;s Consultation Notes</span>
+                <span className="text-sm text-gray-500 dark:text-gray-400">{formatTime(elapsed)}</span>
+                <button
+                  onClick={() => setRunning((prev) => !prev)}
+                  className="text-sm text-brand-500"
+                >
+                  {running ? 'Pause' : 'Resume'}
+                </button>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={copyToClipboard}
+                  className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                >
+                  <CopyIcon className="h-5 w-5" />
+                </button>
+                <button
+                  onClick={() => setOpen(false)}
+                  className="text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                >
+                  <CloseIcon className="h-5 w-5" />
+                </button>
+              </div>
             </div>
-            <div className="flex items-center gap-2">
-              <button
-                onClick={copyToClipboard}
-                className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
-              >
-                <CopyIcon className="h-5 w-5" />
-              </button>
-              <button
-                onClick={() => setOpen(false)}
-                className="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
-              >
-                <CloseIcon className="h-5 w-5" />
-              </button>
+            <textarea
+              className="flex-1 resize-none bg-transparent p-3 text-sm text-gray-800 dark:text-gray-100 outline-none"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+            />
+            <div className="p-2 text-right text-xs text-gray-500 dark:text-gray-400">
+              {saved ? 'Saved' : 'Saving...'}
             </div>
-          </div>
-          <textarea
-            className="flex-1 resize-none bg-transparent p-3 text-sm outline-none"
-            value={content}
-            onChange={(e) => setContent(e.target.value)}
-          />
-          <div className="p-2 text-right text-xs text-gray-500">
-            {saved ? 'Saved' : 'Saving...'}
           </div>
         </div>
       )}

--- a/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
+++ b/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
@@ -7,6 +7,7 @@ import Alert from "@/components/ui/alert/Alert";
 import { Dropdown } from "../ui/dropdown/Dropdown";
 import { DropdownItem } from "../ui/dropdown/DropdownItem";
 import ConsultationNotes from "@/components/consultation/ConsultationNotes";
+import { chestPainText, headacheText } from "@/data/presentations";
 
 export const EcommerceMetrics: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -22,11 +23,17 @@ export const EcommerceMetrics: React.FC = () => {
   const initialNotes = `Eunji Lee 33 F
 Tags: Clinical need: High, Medication change, Certificate, English as second language
 
+Patient’s headache began 2 weeks ago, worsening over the duration. Consistent pain with intermittent sharpness. Exacerbates with stress. No nausea or vomiting. Currently takes panadol.
+
 Idea: I think I'm tired from work and stressed at home, giving me a headache
 Concerns: I'm worried about potential heart problems
 Expectation: I want reassurance and a medical certificate to take time off of work
 
-Patient’s headache began 2 weeks ago, worsening over the duration. Consistent pain with intermittent sharpness. Exacerbates with stress. No nausea or vomiting. Currently takes panadol.`;
+Chest Pain
+${chestPainText}
+
+Headache
+${headacheText}`;
 
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:gap-6">

--- a/next-dashboard/src/components/ecommerce/PresentationTabs.tsx
+++ b/next-dashboard/src/components/ecommerce/PresentationTabs.tsx
@@ -2,12 +2,10 @@
 
 import React, { useState } from "react";
 import { CopyIcon } from "@/icons";
+import { chestPainText, headacheText } from "@/data/presentations";
 
 const PresentationTabs: React.FC = () => {
   const [selected, setSelected] = useState<"chest" | "headache">("chest");
-
-  const chestPainText = `Severity: 6/10\nOnset: Uncertain\nExperienced for more than a few months, uncertain for how long.\nCharacter: Stinging pain\nRelated Symptoms: 0 Indicated\nCurrent Management: No steps taken`;
-  const headacheText = "No details available.";
 
   const copyToClipboard = (text: string) => {
     if (navigator?.clipboard) {
@@ -57,7 +55,7 @@ const PresentationTabs: React.FC = () => {
 
   const renderHeadache = () => (
     <div>
-      <p className="text-gray-500 dark:text-gray-400">No details available.</p>
+      <p className="text-gray-500 dark:text-gray-400">{headacheText}</p>
     </div>
   );
 

--- a/next-dashboard/src/data/presentations.ts
+++ b/next-dashboard/src/data/presentations.ts
@@ -1,0 +1,3 @@
+export const chestPainText = `Severity: 6/10\nOnset: Uncertain\nExperienced for more than a few months, uncertain for how long.\nCharacter: Stinging pain\nRelated Symptoms: 0 Indicated\nCurrent Management: No steps taken`;
+
+export const headacheText = `No details available.`;


### PR DESCRIPTION
## Summary
- Center consultation notes modal with dark overlay and visible red exit button for consistent dark mode experience.
- Reorder initial consultation notes to start with executive summary followed by ICE information and clearly separated presenting symptoms.
- Centralize presenting symptom text data and reuse it across presentation tabs and consultation notes.

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b528f38e5c8332878e7f86ec562d01