### PR TITLE
Refine Chest Pain presentation and exit button styling

### DIFF
--- a/next-dashboard/src/components/consultation/ConsultationNotes.tsx
+++ b/next-dashboard/src/components/consultation/ConsultationNotes.tsx
@@ -81,7 +81,7 @@ const ConsultationNotes: React.FC<ConsultationNotesProps> = ({ initialContent })
             <button
               onClick={() => setOpen(false)}
               aria-label="Close consultation notes"
-              className="absolute top-4 right-4 rounded-full bg-red-500 p-2 text-white hover:bg-red-600"
+              className="absolute top-4 right-4 p-2 text-red-500 hover:text-red-600"
             >
               <CloseIcon className="h-4 w-4" />
             </button>

--- a/next-dashboard/src/components/ecommerce/Presentations.tsx
+++ b/next-dashboard/src/components/ecommerce/Presentations.tsx
@@ -9,47 +9,33 @@ const Presentations: React.FC = () => {
         <div className="mt-2">
           <Badge variant="solid" color="info">Physical acute</Badge>
         </div>
-        <div className="mt-6">
-          <dl className="grid grid-cols-1 sm:grid-cols-[max-content_1fr] gap-x-3 gap-y-2 items-start md:gap-x-4 md:gap-y-3">
-            <dt className="px-4 py-2 rounded-lg bg-gray-100 text-gray-700 dark:bg-white/5 dark:text-white/80 whitespace-nowrap">
-              Severity
-            </dt>
-            <dd className="px-4 py-2 rounded-lg bg-brand-50 text-brand-500 break-words min-w-0 dark:bg-brand-500/[0.12] dark:text-brand-400">
-              6/10
-            </dd>
-
-            <dt className="px-4 py-2 rounded-lg bg-gray-100 text-gray-700 dark:bg-white/5 dark:text-white/80 whitespace-nowrap">
-              Onset
-            </dt>
-            <dd className="px-4 py-2 rounded-lg bg-brand-50 text-brand-500 break-words min-w-0 dark:bg-brand-500/[0.12] dark:text-brand-400">
-              <div className="font-medium text-gray-800 dark:text-white/90">Uncertain</div>
-              <p className="mt-2 text-gray-500 dark:text-gray-400">
+        <dl className="mt-6 grid grid-cols-1 gap-y-2 sm:grid-cols-2 sm:gap-4">
+          <div>
+            <dt className="text-gray-500 dark:text-gray-400">Severity</dt>
+            <dd className="font-medium text-gray-800 dark:text-white/90">6/10</dd>
+          </div>
+          <div>
+            <dt className="text-gray-500 dark:text-gray-400">Onset</dt>
+            <dd className="font-medium text-gray-800 dark:text-white/90">
+              <div>Uncertain</div>
+              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
                 Experienced for more than a few months, uncertain for how long.
               </p>
             </dd>
-
-            <dt className="px-4 py-2 rounded-lg bg-gray-100 text-gray-700 dark:bg-white/5 dark:text-white/80 whitespace-nowrap">
-              Character
-            </dt>
-            <dd className="px-4 py-2 rounded-lg bg-brand-50 text-brand-500 break-words min-w-0 dark:bg-brand-500/[0.12] dark:text-brand-400">
-              Stinging pain
-            </dd>
-
-            <dt className="px-4 py-2 rounded-lg bg-gray-100 text-gray-700 dark:bg-white/5 dark:text-white/80 whitespace-nowrap">
-              Related Symptoms
-            </dt>
-            <dd className="px-4 py-2 rounded-lg bg-brand-50 text-brand-500 break-words min-w-0 dark:bg-brand-500/[0.12] dark:text-brand-400">
-              0 Indicated
-            </dd>
-
-            <dt className="px-4 py-2 rounded-lg bg-gray-100 text-gray-700 dark:bg-white/5 dark:text-white/80 whitespace-nowrap">
-              Current Management
-            </dt>
-            <dd className="px-4 py-2 rounded-lg bg-brand-50 text-brand-500 break-words min-w-0 dark:bg-brand-500/[0.12] dark:text-brand-400">
-              No steps taken
-            </dd>
-          </dl>
-        </div>
+          </div>
+          <div>
+            <dt className="text-gray-500 dark:text-gray-400">Character</dt>
+            <dd className="font-medium text-gray-800 dark:text-white/90">Stinging pain</dd>
+          </div>
+          <div>
+            <dt className="text-gray-500 dark:text-gray-400">Related Symptoms</dt>
+            <dd className="font-medium text-gray-800 dark:text-white/90">0 Indicated</dd>
+          </div>
+          <div>
+            <dt className="text-gray-500 dark:text-gray-400">Current Management</dt>
+            <dd className="font-medium text-gray-800 dark:text-white/90">No steps taken</dd>
+          </div>
+        </dl>
       </div>
 
       <div className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-white/[0.03] md:p-6">


### PR DESCRIPTION
## Summary
- Replace Chest Pain mini-card layout with streamlined list matching Migraine styling
- Restyle consultation popup close button to display a red X icon without circular background

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b571b17f2c83329d1634e88c4320a5