### PR TITLE
Refactor dashboard to source patient info from data file

### DIFF
--- a/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
+++ b/next-dashboard/src/components/ecommerce/EcommerceMetrics.tsx
@@ -7,10 +7,34 @@ import Alert from "@/components/ui/alert/Alert";
 import { Dropdown } from "../ui/dropdown/Dropdown";
 import { DropdownItem } from "../ui/dropdown/DropdownItem";
 import ConsultationNotes from "@/components/consultation/ConsultationNotes";
-import { chestPainText, migraineText } from "@/data/presentations";
+import { patient } from "@/data/patient";
+
+const getAge = (dob: string) => {
+  const diff = Date.now() - new Date(dob).getTime();
+  const ageDt = new Date(diff);
+  return Math.abs(ageDt.getUTCFullYear() - 1970);
+};
 
 export const EcommerceMetrics: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const age = getAge(patient.date_of_birth);
+  const notesFromPresentations = patient.presenting_symptoms
+    .map((sym) => `${sym.label}\n${sym.notes}`)
+    .join("\n\n");
+  const tagsText = [
+    `NHI: ${patient.nhi_number}`,
+    `Clinical need: ${patient.clinical_need}`,
+    ...patient.tags,
+    "English as second language",
+  ].join(", ");
+  const initialNotes =
+    `${patient.first_name} ${patient.last_name} ${age} ${patient.gender}\n` +
+    `Tags: ${tagsText}\n\n` +
+    `${patient.chief_complaint}\n\n` +
+    `Idea: ${patient.ice.idea}\n` +
+    `Concerns: ${patient.ice.concern}\n` +
+    `Expectation: ${patient.ice.expectation}\n\n` +
+    `${notesFromPresentations}`;
 
   function toggleMenu() {
     setIsMenuOpen(!isMenuOpen);
@@ -19,21 +43,6 @@ export const EcommerceMetrics: React.FC = () => {
   function closeMenu() {
     setIsMenuOpen(false);
   }
-
-  const initialNotes = `Eunji Lee 33 F
-Tags: NHI: NHIUAU2990, Clinical need: High, Medication change, Certificate, English as second language
-
-Patient’s migraine began 2 weeks ago, worsening over the duration. Consistent pain with intermittent sharpness. Exacerbates with stress. No nausea or vomiting. Currently takes panadol.
-
-Idea: I think I'm tired from work and stressed at home, giving me a migraine
-Concerns: I'm worried about potential heart problems
-Expectation: I want reassurance and a medical certificate to take time off of work
-
-Chest Pain
-${chestPainText}
-
-Migraine
-${migraineText}`;
 
   return (
     <div className="space-y-4 md:space-y-6">
@@ -44,10 +53,10 @@ ${migraineText}`;
           <div className="flex items-start justify-between gap-3">
             <div>
               <h3 className="text-lg font-semibold text-gray-800 dark:text-white/90">
-                Eunji Lee 33 F
+                {patient.first_name} {patient.last_name} {age} {patient.gender}
               </h3>
               <p className="mt-1 text-gray-500 text-theme-xs dark:text-gray-400">
-                Submitted today at 8:15 AM
+                {patient.ended_at}
               </p>
             </div>
             <div className="flex flex-col items-end gap-2">
@@ -74,27 +83,50 @@ ${migraineText}`;
                 </Dropdown>
               </div>
               <div className="flex flex-wrap gap-2 justify-end text-right">
-                <Badge variant="light" color="success">NHIUAU2990</Badge>
-                <Badge variant="solid" color="warning">Clinical need: High</Badge>
-                <Badge variant="solid" color="info">Medication change</Badge>
-                <Badge variant="solid" color="info">Certificate</Badge>
-                <Badge variant="solid" color="info">English as second language</Badge>
+                {[
+                  { label: patient.nhi_number, variant: "light", color: "success" as const },
+                  {
+                    label: `Clinical need: ${patient.clinical_need}`,
+                    variant: "solid",
+                    color: "warning" as const,
+                  },
+                  ...patient.tags.map((tag) => ({
+                    label: tag,
+                    variant: "solid",
+                    color: "info" as const,
+                  })),
+                  {
+                    label: `ESL: ${patient.preferred_language} preferred`,
+                    variant: "solid",
+                    color: "info" as const,
+                  },
+                ].map((badge) => (
+                  <Badge
+                    key={badge.label}
+                    variant={badge.variant}
+                    color={badge.color}
+                  >
+                    {badge.label}
+                  </Badge>
+                ))}
               </div>
             </div>
           </div>
-          <div className="mt-3">
-            <Alert
-              variant="info"
-              message="This Pre-consult was translated from Korean"
-              size="sm"
-            />
-          </div>
+          {patient.translated_from && (
+            <div className="mt-3">
+              <Alert
+                variant="info"
+                message={`This Pre-consult was translated from ${patient.translated_from}`}
+                size="sm"
+              />
+            </div>
+          )}
         </div>
         <div className="mt-3">
           {/* Attached grey footer (duplicated style) */}
           <div className="flex items-center justify-center gap-5 px-6 py-3 sm:gap-8 sm:py-4">
             <dt className="rounded-lg bg-gray-100 text-gray-700 dark:bg-white/5 dark:text-white/80 text-sm line-clamp-3">
-              Patient’s migraine began 2 weeks ago, worsening over the duration. Consistent pain with intermittent sharpness. Exacerbates with stress. No nausea or vomiting. Currently takes panadol.
+              {patient.chief_complaint}
             </dt>
           </div>
         </div>

--- a/next-dashboard/src/components/ecommerce/IceModelCard.tsx
+++ b/next-dashboard/src/components/ecommerce/IceModelCard.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { patient } from "@/data/patient";
 
 const IceModelCard: React.FC = () => {
   return (
@@ -9,21 +10,21 @@ const IceModelCard: React.FC = () => {
           Idea
         </dt>
         <dd className="px-4 py-2 rounded-lg bg-brand-50 text-brand-500 break-words min-w-0 dark:bg-brand-500/[0.12] dark:text-brand-400">
-          I think I&apos;m tired from work and stressed at home, giving me a migraine
+          {patient.ice.idea}
         </dd>
 
         <dt className="px-4 py-2 rounded-lg bg-gray-100 text-gray-700 dark:bg-white/5 dark:text-white/80 whitespace-nowrap">
           Concerns
         </dt>
         <dd className="px-4 py-2 rounded-lg bg-brand-50 text-brand-500 break-words min-w-0 dark:bg-brand-500/[0.12] dark:text-brand-400">
-          I&apos;m worried about potential heart problems
+          {patient.ice.concern}
         </dd>
 
         <dt className="px-4 py-2 rounded-lg bg-gray-100 text-gray-700 dark:bg-white/5 dark:text-white/80 whitespace-nowrap">
           Expectation
         </dt>
         <dd className="px-4 py-2 rounded-lg bg-brand-50 text-brand-500 break-words min-w-0 dark:bg-brand-500/[0.12] dark:text-brand-400">
-          I want reassurance and a medical certificate to take time off of work
+          {patient.ice.expectation}
         </dd>
       </dl>
     </div>

--- a/next-dashboard/src/components/ecommerce/Presentations.tsx
+++ b/next-dashboard/src/components/ecommerce/Presentations.tsx
@@ -1,75 +1,46 @@
 import React from "react";
 import Badge from "../ui/badge/Badge";
+import { AlertIcon } from "@/icons";
+import { patient } from "@/data/patient";
 
 const Presentations: React.FC = () => {
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-6">
-      <div className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-white/[0.03] md:p-6">
-        <h3 className="text-lg font-semibold text-gray-800 dark:text-white/90">Chest Pain</h3>
-        <div className="mt-2">
-          <Badge variant="solid" color="info">Physical acute</Badge>
+      {patient.presenting_symptoms.map((symptom) => (
+        <div
+          key={symptom.label}
+          className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-white/[0.03] md:p-6"
+        >
+          <h3 className="text-lg font-semibold text-gray-800 dark:text-white/90">
+            {symptom.label}
+            {symptom.is_red_flag && (
+              <AlertIcon className="inline-block ml-2 text-red-500" />
+            )}
+          </h3>
+          <div className="mt-2">
+            <Badge variant="solid" color="info">
+              {symptom.type}
+            </Badge>
+          </div>
+          <dl className="mt-6 grid grid-cols-1 gap-y-2 sm:grid-cols-2 sm:gap-4">
+            {symptom.details.map((detail) => (
+              <div key={detail.term}>
+                <dt className="text-gray-500 dark:text-gray-400">
+                  {detail.term}
+                </dt>
+                <dd className="font-medium text-gray-800 dark:text-white/90">
+                  {detail.detail}
+                  {detail.subDetail && (
+                    <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                      {detail.subDetail}
+                    </p>
+                  )}
+                </dd>
+              </div>
+            ))}
+          </dl>
         </div>
-        <dl className="mt-6 grid grid-cols-1 gap-y-2 sm:grid-cols-2 sm:gap-4">
-          <div>
-            <dt className="text-gray-500 dark:text-gray-400">Severity</dt>
-            <dd className="font-medium text-gray-800 dark:text-white/90">6/10</dd>
-          </div>
-          <div>
-            <dt className="text-gray-500 dark:text-gray-400">Onset</dt>
-            <dd className="font-medium text-gray-800 dark:text-white/90">
-              <div>Uncertain</div>
-              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                Experienced for more than a few months, uncertain for how long.
-              </p>
-            </dd>
-          </div>
-          <div>
-            <dt className="text-gray-500 dark:text-gray-400">Character</dt>
-            <dd className="font-medium text-gray-800 dark:text-white/90">Stinging pain</dd>
-          </div>
-          <div>
-            <dt className="text-gray-500 dark:text-gray-400">Related Symptoms</dt>
-            <dd className="font-medium text-gray-800 dark:text-white/90">0 Indicated</dd>
-          </div>
-          <div>
-            <dt className="text-gray-500 dark:text-gray-400">Current Management</dt>
-            <dd className="font-medium text-gray-800 dark:text-white/90">No steps taken</dd>
-          </div>
-        </dl>
-      </div>
-
-      <div className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-white/[0.03] md:p-6">
-        <h3 className="text-lg font-semibold text-gray-800 dark:text-white/90">Migraine</h3>
-        <div className="mt-2">
-          <Badge variant="solid" color="info">Chronic</Badge>
-        </div>
-        <dl className="mt-6 grid grid-cols-1 gap-y-2 sm:grid-cols-2 sm:gap-4">
-          <div>
-            <dt className="text-gray-500 dark:text-gray-400">Site</dt>
-            <dd className="font-medium text-gray-800 dark:text-white/90">Head</dd>
-          </div>
-          <div>
-            <dt className="text-gray-500 dark:text-gray-400">Progression</dt>
-            <dd className="font-medium text-gray-800 dark:text-white/90">Consistent</dd>
-          </div>
-          <div>
-            <dt className="text-gray-500 dark:text-gray-400">Interval</dt>
-            <dd className="font-medium text-gray-800 dark:text-white/90">Daily</dd>
-          </div>
-          <div>
-            <dt className="text-gray-500 dark:text-gray-400">Expectation</dt>
-            <dd className="font-medium text-gray-800 dark:text-white/90">Wants medicine change</dd>
-          </div>
-          <div>
-            <dt className="text-gray-500 dark:text-gray-400">Lifestyle</dt>
-            <dd className="font-medium text-gray-800 dark:text-white/90">Sedentary</dd>
-          </div>
-          <div>
-            <dt className="text-gray-500 dark:text-gray-400">Family history</dt>
-            <dd className="font-medium text-gray-800 dark:text-white/90">Mother has Migraine</dd>
-          </div>
-        </dl>
-      </div>
+      ))}
     </div>
   );
 };

--- a/next-dashboard/src/data/patient.ts
+++ b/next-dashboard/src/data/patient.ts
@@ -1,0 +1,55 @@
+export const patient = {
+  first_name: "Eunji",
+  last_name: "Lee",
+  date_of_birth: "1992-08-20",
+  gender: "F",
+  occupation: "Consultant",
+  nhi_number: "NHIUAU2990",
+  clinical_need: "High",
+  tags: ["Medication change", "Medical certificate"],
+  preferred_language: "Korean",
+  ended_at: "Submitted today at 8:15 AM",
+  translated_from: "Korean",
+  chief_complaint:
+    "Patient’s migraine began 2 weeks ago, worsening over the duration. Consistent pain with intermittent sharpness. Exacerbates with stress. No nausea or vomiting. Currently takes panadol.",
+  ice: {
+    idea: "I think I'm tired from work and stressed at home, giving me a migraine",
+    concern: "I'm worried about potential heart problems",
+    expectation: "I want reassurance and a medical certificate to take time off of work",
+  },
+  presenting_symptoms: [
+    {
+      label: "Chest pain",
+      type: "Physical acute",
+      is_red_flag: true,
+      details: [
+        { term: "Severity", detail: "6/10" },
+        {
+          term: "Onset",
+          detail: "Uncertain",
+          subDetail:
+            "Experienced for more than a few months, uncertain for how long.",
+        },
+        { term: "Character", detail: "Stinging pain" },
+        { term: "Related Symptoms", detail: "0 Indicated" },
+        { term: "Current Management", detail: "No steps taken" },
+      ],
+      notes:
+        "Severity: 6/10\nOnset: Uncertain\nExperienced for more than a few months, uncertain for how long.\nCharacter: Stinging pain\nRelated Symptoms: 0 Indicated\nCurrent Management: No steps taken",
+    },
+    {
+      label: "Migraine",
+      type: "Physical acute",
+      details: [
+        { term: "Site", detail: "Head" },
+        { term: "Progression", detail: "Consistent" },
+        { term: "Interval", detail: "Daily" },
+        { term: "Expectation", detail: "Wants medicine change" },
+        { term: "Lifestyle", detail: "Sedentary" },
+        { term: "Family history", detail: "Mother has Migraine" },
+      ],
+      notes: "No details available.",
+    },
+  ],
+  consult_length: "13:12",
+};


### PR DESCRIPTION
## Summary
- add `patient` data module with placeholder demographic, tag, language, and symptom information
- render patient header, tags, translation alert, and notes from data instead of hardcoded strings
- drive ICE model and presentations cards from patient variables, including red flag indicators

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Outfit`)*

------
https://chatgpt.com/codex/tasks/task_e_68b57c5d79908332948522b28cf94ca1