### PR TITLE
fix: handle optional sub-detail in presentations

### DIFF
--- a/next-dashboard/src/components/ecommerce/Presentations.tsx
+++ b/next-dashboard/src/components/ecommerce/Presentations.tsx
@@ -3,6 +3,12 @@ import Badge from "../ui/badge/Badge";
 import { AlertIcon } from "@/icons";
 import { patient } from "@/data/patient";
 
+interface SymptomDetail {
+  term: string;
+  detail: string;
+  subDetail?: string;
+}
+
 const Presentations: React.FC = () => {
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-6">
@@ -23,7 +29,7 @@ const Presentations: React.FC = () => {
             </Badge>
           </div>
           <dl className="mt-6 grid grid-cols-1 gap-y-2 sm:grid-cols-2 sm:gap-4">
-            {symptom.details.map((detail) => (
+            {symptom.details.map((detail: SymptomDetail) => (
               <div key={detail.term}>
                 <dt className="text-gray-500 dark:text-gray-400">
                   {detail.term}


### PR DESCRIPTION
## Summary
- define `SymptomDetail` interface with optional `subDetail`
- type symptom detail mapping to safely render optional notes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Outfit` from Google Fonts)*
- `npx tsc --noEmit` *(fails: Type error in EcommerceMetrics.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b8dc0e99b08332884a6a00c9d2158a