### PR TITLE
Rehaul dashboard and consultation UI

### DIFF
--- a/next-dashboard/src/app/(admin)/page.tsx
+++ b/next-dashboard/src/app/(admin)/page.tsx
@@ -3,6 +3,7 @@ import { PatientSummary } from "@/components/patient/PatientSummary";
 import React from "react";
 import IceModelCard from "@/components/patient/IceModelCard";
 import PresentingSymptoms from "@/components/patient/PresentingSymptoms";
+import SummaryCard from "@/components/patient/SummaryCard";
 
 export const metadata: Metadata = {
   title: "Align | Dashboard",
@@ -11,18 +12,19 @@ export const metadata: Metadata = {
 
 export default function Dashboard() {
   return (
-    <div className="grid grid-cols-12 gap-4 md:gap-6">
-      <div className="col-span-12 space-y-6 lg:col-span-6">
-        <PatientSummary />
-      </div>
+    <div className="space-y-6">
+      <PatientSummary />
 
-      <div className="col-span-12 lg:col-span-6 flex">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-6">
+        <SummaryCard />
         <IceModelCard />
       </div>
 
-      <div className="col-span-12">
-        <PresentingSymptoms />
-      </div>
+      <h2 className="text-lg font-semibold text-gray-800 dark:text-white/90">
+        Presentation History
+      </h2>
+
+      <PresentingSymptoms />
     </div>
   );
 }

--- a/next-dashboard/src/components/consultation/ConsultationNotes.tsx
+++ b/next-dashboard/src/components/consultation/ConsultationNotes.tsx
@@ -1,25 +1,35 @@
-'use client';
+"use client";
 
-import React, { useState, useEffect } from 'react';
-import { DocsIcon, CopyIcon, CloseIcon } from '@/icons';
+import React, { useState, useEffect } from "react";
+import { DocsIcon, CopyIcon, CloseIcon, PencilIcon } from "@/icons";
+import { patient } from "@/data/patient";
 
-interface ConsultationNotesProps {
-  initialContent: string;
+interface PresentationField {
+  label: string;
+  text: string;
 }
 
-const ConsultationNotes: React.FC<ConsultationNotesProps> = ({ initialContent }) => {
+const ConsultationNotes: React.FC = () => {
   const [open, setOpen] = useState(false);
-  const [content, setContent] = useState(initialContent);
   const [elapsed, setElapsed] = useState(0);
   const [running, setRunning] = useState(false);
-  const [saved, setSaved] = useState(true);
+  const [tags, setTags] = useState<string[]>([...patient.tags]);
+  const [editingTag, setEditingTag] = useState<number | null>(null);
+  const [patientSummary, setPatientSummary] = useState(patient.chief_complaint);
+  const [iceSummary, setIceSummary] = useState(
+    `Idea: ${patient.ice.idea}\nConcerns: ${patient.ice.concern}\nExpectation: ${patient.ice.expectation}`
+  );
+  const [presentations, setPresentations] = useState<PresentationField[]>(
+    patient.presenting_symptoms.map((sym) => ({
+      label: sym.label,
+      text: sym.notes,
+    }))
+  );
 
   useEffect(() => {
     let interval: NodeJS.Timeout | undefined;
     if (running) {
-      interval = setInterval(() => {
-        setElapsed((prev) => prev + 1);
-      }, 1000);
+      interval = setInterval(() => setElapsed((prev) => prev + 1), 1000);
     }
     return () => interval && clearInterval(interval);
   }, [running]);
@@ -36,31 +46,50 @@ const ConsultationNotes: React.FC<ConsultationNotesProps> = ({ initialContent })
   useEffect(() => {
     if (!open) return;
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        setOpen(false);
-      }
+      if (e.key === "Escape") setOpen(false);
     };
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
   }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    setSaved(false);
-    const handle = setTimeout(() => setSaved(true), 500);
-    return () => clearTimeout(handle);
-  }, [content, open]);
 
   const formatTime = (secs: number) => {
     const minutes = Math.floor(secs / 60);
     const seconds = secs % 60;
-    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
   };
 
-  const copyToClipboard = () => {
+  const copyText = (text: string) => {
+    navigator.clipboard?.writeText(text);
+  };
+
+  const pasteText = async (setter: (text: string) => void) => {
     if (navigator.clipboard) {
-      navigator.clipboard.writeText(content);
+      const t = await navigator.clipboard.readText();
+      setter(t);
     }
+  };
+
+  const updateTag = (index: number, value: string) => {
+    setTags((prev) => prev.map((t, i) => (i === index ? value : t)));
+  };
+
+  const removeTag = (index: number) => {
+    setTags((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const updatePresentation = (index: number, value: string) => {
+    setPresentations((prev) =>
+      prev.map((p, i) => (i === index ? { ...p, text: value } : p))
+    );
+  };
+
+  const copyAll = () => {
+    const tagText = tags.join(", ");
+    const presentationText = presentations
+      .map((p) => `${p.label}\n${p.text}`)
+      .join("\n\n");
+    const all = `${patient.first_name} ${patient.last_name}\nTags: ${tagText}\n\nPatient Summary:\n${patientSummary}\n\nICE Summary:\n${iceSummary}\n\n${presentationText}`;
+    navigator.clipboard?.writeText(all);
   };
 
   return (
@@ -77,11 +106,11 @@ const ConsultationNotes: React.FC<ConsultationNotesProps> = ({ initialContent })
 
       {open && (
         <div className="fixed inset-0 z-[100000] flex items-center justify-center bg-black/50 p-4 sm:p-8">
-          <div className="relative flex h-full w-full flex-col rounded-2xl bg-white shadow-lg dark:bg-gray-900">
+          <div className="relative flex h-full w-full flex-col overflow-y-auto rounded-2xl bg-white shadow-lg dark:bg-gray-900">
             <button
               onClick={() => setOpen(false)}
               aria-label="Close consultation notes"
-              className="absolute top-4 right-4 p-2 text-red-500 hover:text-red-600"
+              className="absolute top-4 right-4 flex h-8 w-8 items-center justify-center rounded-full bg-red-600 text-white"
             >
               <CloseIcon className="h-4 w-4" />
             </button>
@@ -93,25 +122,134 @@ const ConsultationNotes: React.FC<ConsultationNotesProps> = ({ initialContent })
                   onClick={() => setRunning((prev) => !prev)}
                   className="text-sm text-brand-500"
                 >
-                  {running ? 'Pause' : 'Resume'}
+                  {running ? "Pause" : "Resume"}
                 </button>
               </div>
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={copyToClipboard}
-                  className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
-                >
-                  <CopyIcon className="h-5 w-5" />
-                </button>
-              </div>
+              <button
+                onClick={copyAll}
+                className="rounded bg-brand-500 px-4 py-2 text-sm font-medium text-white"
+              >
+                Finish presentation + copy all
+              </button>
             </div>
-            <textarea
-              className="flex-1 resize-none bg-transparent p-3 text-sm text-gray-800 dark:text-gray-100 outline-none"
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-            />
-            <div className="p-2 text-right text-xs text-gray-500 dark:text-gray-400">
-              {saved ? 'Saved' : 'Saving...'}
+
+            <div className="flex-1 space-y-4 overflow-y-auto p-4">
+              <div className="rounded-lg border border-gray-200 p-4 dark:border-gray-700">
+                <h3 className="mb-2 font-semibold text-gray-800 dark:text-white">
+                  {patient.first_name} {patient.last_name}
+                </h3>
+                <div className="flex flex-wrap gap-2">
+                  {tags.map((tag, i) => (
+                    <div
+                      key={i}
+                      className="flex items-center rounded bg-gray-100 px-2 py-1 dark:bg-gray-800"
+                    >
+                      {editingTag === i ? (
+                        <input
+                          value={tag}
+                          onChange={(e) => updateTag(i, e.target.value)}
+                          onBlur={() => setEditingTag(null)}
+                          className="bg-transparent text-sm outline-none"
+                          autoFocus
+                        />
+                      ) : (
+                        <span className="text-sm">{tag}</span>
+                      )}
+                      <button
+                        onClick={() =>
+                          setEditingTag((prev) => (prev === i ? null : i))
+                        }
+                        className="ml-1 text-gray-500 hover:text-gray-700"
+                      >
+                        <PencilIcon className="h-3 w-3" />
+                      </button>
+                      <button
+                        onClick={() => removeTag(i)}
+                        className="ml-1 text-red-500 hover:text-red-600"
+                      >
+                        <CloseIcon className="h-3 w-3" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="relative">
+                <label className="mb-1 block font-medium text-gray-700 dark:text-gray-200">
+                  Patient Summary
+                </label>
+                <textarea
+                  className="w-full rounded border border-gray-200 bg-white p-3 pr-10 text-sm text-gray-800 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  value={patientSummary}
+                  onChange={(e) => setPatientSummary(e.target.value)}
+                />
+                <div className="absolute top-8 right-2 flex gap-2">
+                  <button
+                    onClick={() => copyText(patientSummary)}
+                    className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                  >
+                    <CopyIcon className="h-4 w-4" />
+                  </button>
+                  <button
+                    onClick={() => pasteText(setPatientSummary)}
+                    className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                  >
+                    <DocsIcon className="h-4 w-4" />
+                  </button>
+                </div>
+              </div>
+
+              <div className="relative">
+                <label className="mb-1 block font-medium text-gray-700 dark:text-gray-200">
+                  ICE Summary
+                </label>
+                <textarea
+                  className="w-full rounded border border-gray-200 bg-white p-3 pr-10 text-sm text-gray-800 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  value={iceSummary}
+                  onChange={(e) => setIceSummary(e.target.value)}
+                />
+                <div className="absolute top-8 right-2 flex gap-2">
+                  <button
+                    onClick={() => copyText(iceSummary)}
+                    className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                  >
+                    <CopyIcon className="h-4 w-4" />
+                  </button>
+                  <button
+                    onClick={() => pasteText(setIceSummary)}
+                    className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                  >
+                    <DocsIcon className="h-4 w-4" />
+                  </button>
+                </div>
+              </div>
+
+              {presentations.map((p, i) => (
+                <div key={p.label} className="relative">
+                  <label className="mb-1 block font-medium text-gray-700 dark:text-gray-200">
+                    {p.label}
+                  </label>
+                  <textarea
+                    className="w-full rounded border border-gray-200 bg-white p-3 pr-10 text-sm text-gray-800 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                    value={p.text}
+                    onChange={(e) => updatePresentation(i, e.target.value)}
+                  />
+                  <div className="absolute top-8 right-2 flex gap-2">
+                    <button
+                      onClick={() => copyText(p.text)}
+                      className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                    >
+                      <CopyIcon className="h-4 w-4" />
+                    </button>
+                    <button
+                      onClick={() => pasteText((t) => updatePresentation(i, t))}
+                      className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                    >
+                      <DocsIcon className="h-4 w-4" />
+                    </button>
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/next-dashboard/src/components/patient/PatientSummary.tsx
+++ b/next-dashboard/src/components/patient/PatientSummary.tsx
@@ -18,23 +18,6 @@ const getAge = (dob: string) => {
 export const PatientSummary: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const age = getAge(patient.date_of_birth);
-  const notesFromPresentations = patient.presenting_symptoms
-    .map((sym) => `${sym.label}\n${sym.notes}`)
-    .join("\n\n");
-  const tagsText = [
-    `NHI: ${patient.nhi_number}`,
-    `Clinical need: ${patient.clinical_need}`,
-    ...patient.tags,
-    "English as second language",
-  ].join(", ");
-  const initialNotes =
-    `${patient.first_name} ${patient.last_name} ${age} ${patient.gender}\n` +
-    `Tags: ${tagsText}\n\n` +
-    `${patient.chief_complaint}\n\n` +
-    `Idea: ${patient.ice.idea}\n` +
-    `Concerns: ${patient.ice.concern}\n` +
-    `Expectation: ${patient.ice.expectation}\n\n` +
-    `${notesFromPresentations}`;
 
   function toggleMenu() {
     setIsMenuOpen(!isMenuOpen);
@@ -137,7 +120,7 @@ export const PatientSummary: React.FC = () => {
       </div>
       {/* Metric Item End */}
 
-      <ConsultationNotes initialContent={initialNotes} />
+      <ConsultationNotes />
     </div>
   );
 };

--- a/next-dashboard/src/components/patient/SummaryCard.tsx
+++ b/next-dashboard/src/components/patient/SummaryCard.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import React, { useState } from "react";
+
+const SummaryCard: React.FC = () => {
+  const [pos, setPos] = useState({ x: 50, y: 50 });
+
+  function handleMouseMove(e: React.MouseEvent<HTMLDivElement>) {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = ((e.clientX - rect.left) / rect.width) * 100;
+    const y = ((e.clientY - rect.top) / rect.height) * 100;
+    setPos({ x, y });
+  }
+
+  const summaryText =
+    "Patient’s migraine began 2 weeks ago, worsening over the duration. Consistent pain with intermittent sharpness. Exacerbates with stress. No nausea or vomiting. Currently takes panadol.";
+
+  return (
+    <div
+      onMouseMove={handleMouseMove}
+      className="relative h-full overflow-hidden rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-800 dark:bg-gray-900"
+    >
+      <div
+        className="pointer-events-none absolute inset-0 transition-all duration-300"
+        style={{
+          background: `radial-gradient(at ${pos.x}% ${pos.y}%, rgba(168,85,247,0.25), transparent 60%)`,
+          animation: "pulseGlow 4s ease-in-out infinite",
+        }}
+      />
+      <div className="relative">
+        <h3 className="mb-2 text-lg font-semibold text-gray-800 dark:text-white/90">Summary</h3>
+        <p className="text-xl font-semibold leading-snug text-gray-800 dark:text-white">
+          {summaryText}
+        </p>
+      </div>
+      <style jsx>{`
+        @keyframes pulseGlow {
+          0%, 100% { opacity: 0.8; }
+          50% { opacity: 1; }
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default SummaryCard;


### PR DESCRIPTION
## Summary
- Display patient details full-width with new summary and ICE cards side-by-side and presentation history header
- Add pulsing summary card with cursor-tracking glow
- Redesign consultation popup with visible red exit button, editable tags, split text fields and copy helpers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b8e75300e883328e32a3c9d9270868