### PR TITLE
Polish patient summary and consultation UI

### DIFF
--- a/next-dashboard/src/components/consultation/ConsultationNotes.tsx
+++ b/next-dashboard/src/components/consultation/ConsultationNotes.tsx
@@ -110,7 +110,7 @@ const ConsultationNotes: React.FC = () => {
             <button
               onClick={() => setOpen(false)}
               aria-label="Close consultation notes"
-              className="absolute top-4 right-4 flex h-8 w-8 items-center justify-center rounded-full bg-red-600 text-white"
+              className="absolute top-4 right-4 rounded bg-red-600 px-3 py-2 text-sm text-white"
             >
               <CloseIcon className="h-4 w-4" />
             </button>
@@ -179,22 +179,22 @@ const ConsultationNotes: React.FC = () => {
                   Patient Summary
                 </label>
                 <textarea
-                  className="w-full rounded border border-gray-200 bg-white p-3 pr-10 text-sm text-gray-800 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  className="w-full rounded border border-gray-200 bg-white p-3 pr-10 text-sm text-gray-800 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 min-h-[120px]"
                   value={patientSummary}
                   onChange={(e) => setPatientSummary(e.target.value)}
                 />
-                <div className="absolute top-8 right-2 flex gap-2">
+                <div className="absolute top-3 right-2 flex gap-1">
                   <button
                     onClick={() => copyText(patientSummary)}
-                    className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                    className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
                   >
-                    <CopyIcon className="h-4 w-4" />
+                    <CopyIcon className="h-3 w-3" />
                   </button>
                   <button
                     onClick={() => pasteText(setPatientSummary)}
-                    className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                    className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
                   >
-                    <DocsIcon className="h-4 w-4" />
+                    <DocsIcon className="h-3 w-3" />
                   </button>
                 </div>
               </div>
@@ -204,22 +204,22 @@ const ConsultationNotes: React.FC = () => {
                   ICE Summary
                 </label>
                 <textarea
-                  className="w-full rounded border border-gray-200 bg-white p-3 pr-10 text-sm text-gray-800 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  className="w-full rounded border border-gray-200 bg-white p-3 pr-10 text-sm text-gray-800 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 min-h-[120px]"
                   value={iceSummary}
                   onChange={(e) => setIceSummary(e.target.value)}
                 />
-                <div className="absolute top-8 right-2 flex gap-2">
+                <div className="absolute top-3 right-2 flex gap-1">
                   <button
                     onClick={() => copyText(iceSummary)}
-                    className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                    className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
                   >
-                    <CopyIcon className="h-4 w-4" />
+                    <CopyIcon className="h-3 w-3" />
                   </button>
                   <button
                     onClick={() => pasteText(setIceSummary)}
-                    className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                    className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
                   >
-                    <DocsIcon className="h-4 w-4" />
+                    <DocsIcon className="h-3 w-3" />
                   </button>
                 </div>
               </div>
@@ -230,22 +230,22 @@ const ConsultationNotes: React.FC = () => {
                     {p.label}
                   </label>
                   <textarea
-                    className="w-full rounded border border-gray-200 bg-white p-3 pr-10 text-sm text-gray-800 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                    className="w-full rounded border border-gray-200 bg-white p-3 pr-10 text-sm text-gray-800 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 min-h-[120px]"
                     value={p.text}
                     onChange={(e) => updatePresentation(i, e.target.value)}
                   />
-                  <div className="absolute top-8 right-2 flex gap-2">
+                  <div className="absolute top-3 right-2 flex gap-1">
                     <button
                       onClick={() => copyText(p.text)}
-                      className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                      className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
                     >
-                      <CopyIcon className="h-4 w-4" />
+                      <CopyIcon className="h-3 w-3" />
                     </button>
                     <button
                       onClick={() => pasteText((t) => updatePresentation(i, t))}
-                      className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                      className="p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
                     >
-                      <DocsIcon className="h-4 w-4" />
+                      <DocsIcon className="h-3 w-3" />
                     </button>
                   </div>
                 </div>

--- a/next-dashboard/src/components/patient/PatientSummary.tsx
+++ b/next-dashboard/src/components/patient/PatientSummary.tsx
@@ -65,38 +65,6 @@ export const PatientSummary: React.FC = () => {
                   </DropdownItem>
                 </Dropdown>
               </div>
-              <div className="flex flex-wrap gap-2 justify-end text-right">
-                  {[
-                    {
-                      label: patient.nhi_number,
-                      variant: "light" as const,
-                      color: "success" as const,
-                    },
-                    {
-                      label: `Clinical need: ${patient.clinical_need}`,
-                      variant: "solid" as const,
-                      color: "warning" as const,
-                    },
-                    ...patient.tags.map((tag) => ({
-                      label: tag,
-                      variant: "solid" as const,
-                      color: "info" as const,
-                    })),
-                    {
-                      label: `ESL: ${patient.preferred_language} preferred`,
-                      variant: "solid" as const,
-                      color: "info" as const,
-                    },
-                  ].map((badge) => (
-                  <Badge
-                    key={badge.label}
-                    variant={badge.variant}
-                    color={badge.color}
-                  >
-                    {badge.label}
-                  </Badge>
-                ))}
-              </div>
             </div>
           </div>
           {patient.translated_from && (
@@ -110,11 +78,38 @@ export const PatientSummary: React.FC = () => {
           )}
         </div>
         <div className="mt-3">
-          {/* Attached grey footer (duplicated style) */}
-          <div className="flex items-center justify-center gap-5 px-6 py-3 sm:gap-8 sm:py-4">
-            <dt className="rounded-lg bg-gray-100 text-gray-700 dark:bg-white/5 dark:text-white/80 text-sm line-clamp-3">
-              {patient.chief_complaint}
-            </dt>
+          {/* Attached grey footer now shows patient tags */}
+          <div className="flex flex-wrap justify-center gap-2 px-6 py-3 sm:gap-3 sm:py-4">
+            {[
+              {
+                label: patient.nhi_number,
+                variant: "light" as const,
+                color: "success" as const,
+              },
+              {
+                label: `Clinical need: ${patient.clinical_need}`,
+                variant: "solid" as const,
+                color: "warning" as const,
+              },
+              ...patient.tags.map((tag) => ({
+                label: tag,
+                variant: "solid" as const,
+                color: "info" as const,
+              })),
+              {
+                label: `ESL: ${patient.preferred_language} preferred`,
+                variant: "solid" as const,
+                color: "info" as const,
+              },
+            ].map((badge) => (
+              <Badge
+                key={badge.label}
+                variant={badge.variant}
+                color={badge.color}
+              >
+                {badge.label}
+              </Badge>
+            ))}
           </div>
         </div>
       </div>

--- a/next-dashboard/src/components/patient/SummaryCard.tsx
+++ b/next-dashboard/src/components/patient/SummaryCard.tsx
@@ -1,32 +1,15 @@
 "use client";
 
-import React, { useState } from "react";
+import React from "react";
 
 const SummaryCard: React.FC = () => {
-  const [pos, setPos] = useState({ x: 50, y: 50 });
-
-  function handleMouseMove(e: React.MouseEvent<HTMLDivElement>) {
-    const rect = e.currentTarget.getBoundingClientRect();
-    const x = ((e.clientX - rect.left) / rect.width) * 100;
-    const y = ((e.clientY - rect.top) / rect.height) * 100;
-    setPos({ x, y });
-  }
 
   const summaryText =
     "Patient’s migraine began 2 weeks ago, worsening over the duration. Consistent pain with intermittent sharpness. Exacerbates with stress. No nausea or vomiting. Currently takes panadol.";
 
   return (
-    <div
-      onMouseMove={handleMouseMove}
-      className="relative h-full overflow-hidden rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-800 dark:bg-gray-900"
-    >
-      <div
-        className="pointer-events-none absolute inset-0 transition-all duration-300"
-        style={{
-          background: `radial-gradient(at ${pos.x}% ${pos.y}%, rgba(168,85,247,0.25), transparent 60%)`,
-          animation: "pulseGlow 4s ease-in-out infinite",
-        }}
-      />
+    <div className="relative h-full overflow-hidden rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-800 dark:bg-gray-900 summary-card">
+      <span className="shimmer"></span>
       <div className="relative">
         <h3 className="mb-2 text-lg font-semibold text-gray-800 dark:text-white/90">Summary</h3>
         <p className="text-xl font-semibold leading-snug text-gray-800 dark:text-white">
@@ -34,9 +17,39 @@ const SummaryCard: React.FC = () => {
         </p>
       </div>
       <style jsx>{`
-        @keyframes pulseGlow {
-          0%, 100% { opacity: 0.8; }
-          50% { opacity: 1; }
+        .summary-card {
+          position: relative;
+          background-image: linear-gradient(
+            315deg,
+            hsl(213deg 95% 91%) 0%,
+            hsl(248deg 100% 86%) 47%,
+            hsl(293deg 78% 89%) 100%
+          );
+          box-shadow: 0 2px 3px 1px hsl(222deg 50% 20% / 50%);
+        }
+        .shimmer {
+          position: absolute;
+          inset: -40px;
+          border-radius: inherit;
+          pointer-events: none;
+          mix-blend-mode: plus-lighter;
+          mask-image: conic-gradient(
+            from var(--mask, 0deg),
+            transparent 0%,
+            transparent 10%,
+            black 36%,
+            black 45%,
+            transparent 50%,
+            transparent 60%,
+            black 85%,
+            black 95%,
+            transparent 100%
+          );
+          animation: spin 3s linear infinite;
+        }
+        @keyframes spin {
+          0% { --mask: 0deg; }
+          100% { --mask: 360deg; }
         }
       `}</style>
     </div>

--- a/next-dashboard/src/layout/AppHeader.tsx
+++ b/next-dashboard/src/layout/AppHeader.tsx
@@ -164,12 +164,12 @@ const AppHeader: React.FC = () => {
             {/* <!-- Dark Mode Toggler --> */}
             <ThemeToggleButton />
             {/* <!-- Dark Mode Toggler --> */}
-
-           <NotificationDropdown /> 
+            <span className="text-sm text-gray-500 dark:text-gray-400">Autosaved</span>
+            <NotificationDropdown />
             {/* <!-- Notification Menu Area --> */}
           </div>
           {/* <!-- User Area --> */}
-          <UserDropdown /> 
+          <UserDropdown />
     
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add shimmering gradient styling to patient summary card.
- Relocate patient tags into gray footer and remove duplicate complaint text.
- Improve consultation popup: larger text areas, smaller icon buttons, square red exit button.
- Display autosave status in header bar.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8fcf25b348332922a1a970966619a