### PR TITLE
feat: update auth pages to use align branding

### DIFF
--- a/next-dashboard/src/app/(full-width-pages)/(auth)/layout.tsx
+++ b/next-dashboard/src/app/(full-width-pages)/(auth)/layout.tsx
@@ -25,12 +25,20 @@ export default function AuthLayout({
                   <Image
                     width={231}
                     height={48}
-                    src="./images/logo/auth-logo.svg"
-                    alt="Logo"
+                    src="/images/logo/Align-Logo-with-words.svg"
+                    alt="Align logo"
+                    className="dark:hidden"
+                  />
+                  <Image
+                    width={231}
+                    height={48}
+                    src="/images/logo/Align-logo-with-words-dark-mode.svg"
+                    alt="Align logo"
+                    className="hidden dark:block"
                   />
                 </Link>
                 <p className="text-center text-gray-400 dark:text-white/60">
-                  Free and Open-Source Tailwind CSS Admin Dashboard Template
+                  Align Medical Dashboard
                 </p>
               </div>
             </div>

--- a/next-dashboard/src/app/(full-width-pages)/(auth)/signin/page.tsx
+++ b/next-dashboard/src/app/(full-width-pages)/(auth)/signin/page.tsx
@@ -2,8 +2,8 @@ import SignInForm from "@/components/auth/SignInForm";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Next.js SignIn Page | TailAdmin - Next.js Dashboard Template",
-  description: "This is Next.js Signin Page TailAdmin Dashboard Template",
+  title: "Align | Sign In",
+  description: "Sign in to Align dashboard",
 };
 
 export default function SignIn() {

--- a/next-dashboard/src/app/(full-width-pages)/(auth)/signup/page.tsx
+++ b/next-dashboard/src/app/(full-width-pages)/(auth)/signup/page.tsx
@@ -2,9 +2,8 @@ import SignUpForm from "@/components/auth/SignUpForm";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Next.js SignUp Page | TailAdmin - Next.js Dashboard Template",
-  description: "This is Next.js SignUp Page TailAdmin Dashboard Template",
-  // other metadata
+  title: "Align | Sign Up",
+  description: "Create an Align account",
 };
 
 export default function SignUp() {


### PR DESCRIPTION
## Summary
- replace auth layout logo with Align logo and update tagline
- update sign in and sign up metadata to Align branding

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b91abac78c83328845b0f34cb56980